### PR TITLE
modify plugin with sync method

### DIFF
--- a/autoload/codequery.vim
+++ b/autoload/codequery.vim
@@ -137,7 +137,7 @@ function! codequery#make_codequery_db(args) abort
             continue
         endif
 
-        if v:version >= 800
+        if v:version >= 800 && !has('nvim')
             echom 'Making DB ...'
             let mydict = {'db_path': db_path,
                          \'callback': function("codequery#db#make_db_callback")}

--- a/autoload/codequery/query.vim
+++ b/autoload/codequery/query.vim
@@ -197,7 +197,7 @@ function! codequery#query#do_query(word) abort
         return
     endif
 
-    if v:version >= 800
+    if v:version >= 800 && !has('nvim')
         echom 'Searching ... [' . a:word . ']'
 
         let job_dict = {'is_append': g:codequery_append_to_qf ? 1 : 0,


### PR DESCRIPTION
I read docs of vim8/neovim and find that the **job apis** are different. 

So, I just add a condition to check the api version.  If we use neovim, the plugin will just use the sync method.