### PR TITLE
扩展额外的 db 存储路径

### DIFF
--- a/autoload/codequery.vim
+++ b/autoload/codequery.vim
@@ -29,15 +29,6 @@ function! s:set_db() abort
     endif
 
 	let g:codequery_db_path = path
-	"let dbs = split(path)
-	"let g:codequery_db_path = ''
-	"for i in range(len(dbs))
-	"	if i
-	"		let g:codequery_db_path .= ' -s '
-	"	endif
-	"	let g:codequery_db_path .= dbs[i]
-	"endfor
-	"echom g:codequery_db_path
     return 1
 endfunction
 
@@ -97,12 +88,7 @@ function! codequery#run_codequery(args) abort
             call s:restore_cwd()
             return
         endif
-
-"		let dbs = split(g:codequery_db_path)
-"		for db in dbs
-"			let g:codequery_db_path = db
-			call codequery#query#do_query(word)
-"		endfor
+		call codequery#query#do_query(word)
     else
         echom 'Wrong Subcommand !'
     endif

--- a/autoload/codequery.vim
+++ b/autoload/codequery.vim
@@ -28,7 +28,7 @@ function! s:set_db() abort
         return 0
     endif
 
-	let g:codequery_db_path = path
+    let g:codequery_db_path = path
     return 1
 endfunction
 
@@ -78,7 +78,7 @@ function! codequery#run_codequery(args) abort
     let cword = codequery#query#get_valid_cursor_word()
 
     if args_num == 0
-		call codequery#query#do_query(cword)
+        call codequery#query#do_query(cword)
     elseif index(g:codequery_subcommands, args[0]) != -1
         call codequery#query#set_options(args)
         let iword = codequery#query#get_valid_input_word(args)
@@ -88,7 +88,7 @@ function! codequery#run_codequery(args) abort
             call s:restore_cwd()
             return
         endif
-		call codequery#query#do_query(word)
+        call codequery#query#do_query(word)
     else
         echom 'Wrong Subcommand !'
     endif
@@ -109,74 +109,74 @@ function! codequery#make_codequery_db(args) abort
             continue
         endif
 
-		let dbs = flatten(add([], split(codequery#db#find_db_path(ft))))
-		for i in range(len(dbs))
-			echo i + 1 .. '. ' .. dbs[i]
-		endfor
+        let dbs = flatten(add([], split(codequery#db#find_db_path(ft))))
+        for i in range(len(dbs))
+            echo i + 1 .. '. ' .. dbs[i]
+        endfor
 
-		let db = ft . '.db'
-		while len(dbs)
-			echo 'Tips: (Terminate operation)Quit: Q/q | (Use new file)New: W/w'
-			let sndb = input('Select File(number): ')
-			echo ' '
-			if sndb == 'q' || sndb == 'Q'
-				return
-			endif
-			if sndb == 'w' || sndb == 'W'
-				if index(g:c_family_filetype_list, ft) != -1
-					let db = 'c_family.db'
-				endif
-				break
-			elseif sndb > 0 && sndb < len(dbs) + 1
-				let db = get(dbs, sndb - 1, '')
-				break
-			else
-				echo 'Invalid Input !'
-			endif
-		endwhile
+        let db = ft . '.db'
+        while len(dbs)
+            echo 'Tips: (Terminate operation)Quit: Q/q | (Use new file)New: W/w'
+            let sndb = input('Select File(number): ')
+            echo ' '
+            if sndb == 'q' || sndb == 'Q'
+                return
+            endif
+            if sndb == 'w' || sndb == 'W'
+                if index(g:c_family_filetype_list, ft) != -1
+                    let db = 'c_family.db'
+                endif
+                break
+            elseif sndb > 0 && sndb < len(dbs) + 1
+                let db = get(dbs, sndb - 1, '')
+                break
+            else
+                echo 'Invalid Input !'
+            endif
+        endwhile
 
-		if ft ==? 'python'
-			let shell_cmd = codequery#db#construct_python_db_build_cmd(db)
-		elseif ft ==? 'javascript'
-			let shell_cmd = codequery#db#construct_javascript_db_build_cmd(db)
-		elseif ft ==? 'ruby'
-			let shell_cmd = codequery#db#construct_ruby_db_build_cmd(db)
-		elseif ft ==? 'go'
-			let shell_cmd = codequery#db#construct_go_db_build_cmd(db)
-		elseif ft ==? 'java'
-			let shell_cmd = codequery#db#construct_java_db_build_cmd(db)
-		elseif index(g:c_family_filetype_list, ft) != -1
-			let shell_cmd = codequery#db#construct_c_db_build_cmd(db)
-		else
-			echom 'No Command For Building .' . ft . ' file'
-			continue
-		endif
+        if ft ==? 'python'
+            let shell_cmd = codequery#db#construct_python_db_build_cmd(db)
+        elseif ft ==? 'javascript'
+            let shell_cmd = codequery#db#construct_javascript_db_build_cmd(db)
+        elseif ft ==? 'ruby'
+            let shell_cmd = codequery#db#construct_ruby_db_build_cmd(db)
+        elseif ft ==? 'go'
+            let shell_cmd = codequery#db#construct_go_db_build_cmd(db)
+        elseif ft ==? 'java'
+            let shell_cmd = codequery#db#construct_java_db_build_cmd(db)
+        elseif index(g:c_family_filetype_list, ft) != -1
+            let shell_cmd = codequery#db#construct_c_db_build_cmd(db)
+        else
+            echom 'No Command For Building .' . ft . ' file'
+            continue
+        endif
 
-		if has('nvim')
-			echom 'Making DB ...'
-			let mydict = {'db_path': db,
-						 \'callback': function("codequery#db#make_db_nvim_callback")}
-			let callbacks = {'on_exit': mydict.callback}
-			let s:build_job = jobstart(['/bin/sh', '-c', shell_cmd], callbacks)
-		elseif v:version >= 800
-			echom 'Making DB ...'
-			let mydict = {'db_path': db,
-						 \'callback': function("codequery#db#make_db_callback")}
-			let options = {'out_io': 'null',
-						  \'exit_cb': mydict.callback}
-			let s:build_job = job_start(['/bin/sh', '-c', shell_cmd], options)
-			let timer = timer_start(500,
-								   \{-> execute("call job_status(s:build_job)","")},
-								   \{'repeat': 60})
-		elseif exists(':Start')
-			silent execute 'Start! -title=Make_CodeQuery_DB -wait=error ' . shell_cmd
-			redraw!
-			echom 'Making ... ' . db . ' => Run :CodeQueryViewDB to Check Status'
-		else
-			silent execute '!' . shell_cmd
-			redraw!
-		endif
-	endfor
+        if has('nvim')
+            echom 'Making DB ...'
+            let mydict = {'db_path': db,
+                         \'callback': function("codequery#db#make_db_nvim_callback")}
+            let callbacks = {'on_exit': mydict.callback}
+            let s:build_job = jobstart(['/bin/sh', '-c', shell_cmd], callbacks)
+        elseif v:version >= 800
+            echom 'Making DB ...'
+            let mydict = {'db_path': db,
+                         \'callback': function("codequery#db#make_db_callback")}
+            let options = {'out_io': 'null',
+                          \'exit_cb': mydict.callback}
+            let s:build_job = job_start(['/bin/sh', '-c', shell_cmd], options)
+            let timer = timer_start(500,
+                                   \{-> execute("call job_status(s:build_job)","")},
+                                   \{'repeat': 60})
+        elseif exists(':Start')
+            silent execute 'Start! -title=Make_CodeQuery_DB -wait=error ' . shell_cmd
+            redraw!
+            echom 'Making ... ' . db . ' => Run :CodeQueryViewDB to Check Status'
+        else
+            silent execute '!' . shell_cmd
+            redraw!
+        endif
+    endfor
     call s:restore_cwd()
 endfunction
 
@@ -195,19 +195,19 @@ function! codequery#view_codequery_db(args) abort
         endif
 
         let db_path = split(codequery#db#find_db_path(ft))
-		if !len(db_path)
-			if index(g:c_family_filetype_list, ft) != -1
-				execute '!echo "\n(c family) DB Not Found"'
-			else
-				execute '!echo "\n(' . ft . ') DB Not Found"'
-			endif
-			continue
-		endif
-		let dbs = flatten(add([], db_path))
-		for db in dbs
-"			execute '!echo \"\n(' . db . ') is update at: \"  &&  stat -f \"\%Sm" ' . db
-			execute '!echo "(' . db . ') is update at: "  &&  stat -f ' . db
-		endfor
+        if !len(db_path)
+            if index(g:c_family_filetype_list, ft) != -1
+                execute '!echo "\n(c family) DB Not Found"'
+            else
+                execute '!echo "\n(' . ft . ') DB Not Found"'
+            endif
+            continue
+        endif
+        let dbs = flatten(add([], db_path))
+        for db in dbs
+"            execute '!echo \"\n(' . db . ') is update at: \"  &&  stat -f \"\%Sm" ' . db
+            execute '!echo "(' . db . ') is update at: "  &&  stat -f ' . db
+        endfor
     endfor
     call s:restore_cwd()
 endfunction
@@ -228,9 +228,9 @@ function! codequery#move_codequery_db_to_git_hidden_dir(args) abort
         endif
         let git_root_dir = systemlist('git rev-parse --show-toplevel')[0]
         let db_path = codequery#db#find_db_path(ft)
-		if len(split(db_path)) > 1
-			db_path = ''
-		endif
+        if len(split(db_path)) > 1
+            db_path = ''
+        endif
 
         if !v:shell_error && strlen(db_path)
             let new_db_path = git_root_dir . '/.git/codequery/' . db_name

--- a/autoload/codequery.vim
+++ b/autoload/codequery.vim
@@ -205,8 +205,7 @@ function! codequery#view_codequery_db(args) abort
         endif
         let dbs = flatten(add([], db_path))
         for db in dbs
-"            execute '!echo \"\n(' . db . ') is update at: \"  &&  stat -f \"\%Sm" ' . db
-            execute '!echo "(' . db . ') is update at: "  &&  stat -f ' . db
+            execute '!echo "' . db . '   " $(stat -f "\%Sm" ' . db . ')'
         endfor
     endfor
     call s:restore_cwd()

--- a/autoload/codequery/db.vim
+++ b/autoload/codequery/db.vim
@@ -2,6 +2,25 @@
 " Entries
 
 
+let g:module_api_path_point = $codequery_base_db_path ? $codequery_base_db_path : expand('$HOME') . '/' . '.doctype'
+function! codequery#db#module_found(filetype)
+	return codequery#db#path_module_found(g:module_api_path_point, '.*' . a:filetype . '\.db')
+endfunction
+
+function! codequery#db#path_module_found(basepath, match_rule_matchstr)
+	let dbs = []
+	if isdirectory(a:basepath)
+		let objs = split(globpath(a:basepath, '**'), '\n')
+		for obj in objs
+			if strlen(matchstr(obj, '.*' . a:match_rule_matchstr))
+				call add(dbs, obj)
+			endif
+		endfor
+	endif
+	return dbs
+endfunction
+
+
 " `lcd` brings side effect !!
 function! codequery#db#find_db_path(filetype) abort
     if index(g:c_family_filetype_list, a:filetype) != -1
@@ -30,9 +49,17 @@ function! codequery#db#find_db_path(filetype) abort
             if !empty(lookup_path)
                 execute 'lcd ' . git_root_dir
                 return lookup_path
+			else
+				let cache_paths = codequery#db#module_found(a:filetype)
+				let lookup_path = join(cache_paths)
+				if strlen(lookup_path)
+					execute 'lcd ' . git_root_dir
+					return lookup_path
+				endif
             endif
         endif
     endif
+	return ''
 endfunction
 
 

--- a/autoload/codequery/db.vim
+++ b/autoload/codequery/db.vim
@@ -4,20 +4,20 @@
 
 let g:module_api_path_point = $codequery_base_db_path ? $codequery_base_db_path : expand('$HOME') . '/' . '.doctype'
 function! codequery#db#module_found(filetype)
-	return codequery#db#path_module_found(g:module_api_path_point, '.*' . a:filetype . '\.db')
+    return codequery#db#path_module_found(g:module_api_path_point, '.*' . a:filetype . '\.db')
 endfunction
 
 function! codequery#db#path_module_found(basepath, match_rule_matchstr)
-	let dbs = []
-	if isdirectory(a:basepath)
-		let objs = split(globpath(a:basepath, '**'), '\n')
-		for obj in objs
-			if strlen(matchstr(obj, '.*' . a:match_rule_matchstr))
-				call add(dbs, obj)
-			endif
-		endfor
-	endif
-	return dbs
+    let dbs = []
+    if isdirectory(a:basepath)
+        let objs = split(globpath(a:basepath, '**'), '\n')
+        for obj in objs
+            if strlen(matchstr(obj, '.*' . a:match_rule_matchstr))
+                call add(dbs, obj)
+            endif
+        endfor
+    endif
+    return dbs
 endfunction
 
 
@@ -49,17 +49,17 @@ function! codequery#db#find_db_path(filetype) abort
             if !empty(lookup_path)
                 execute 'lcd ' . git_root_dir
                 return lookup_path
-			else
-				let cache_paths = codequery#db#module_found(a:filetype)
-				let lookup_path = join(cache_paths)
-				if strlen(lookup_path)
-					execute 'lcd ' . git_root_dir
-					return lookup_path
-				endif
+            else
+                let cache_paths = codequery#db#module_found(a:filetype)
+                let lookup_path = join(cache_paths)
+                if strlen(lookup_path)
+                    execute 'lcd ' . git_root_dir
+                    return lookup_path
+                endif
             endif
         endif
     endif
-	return ''
+    return ''
 endfunction
 
 

--- a/autoload/codequery/query.vim
+++ b/autoload/codequery/query.vim
@@ -29,9 +29,6 @@ function! s:create_grep_options(word) abort
 
     let grepformat = '%f:%l%m'
 
-"    let grepprg = 'cqsearch -s ' . g:codequery_db_path . ' -p ' . g:codequery_querytype . ' -t '
-"                \ . word . ' -u ' . fuzzy_option . pipeline_script_option
-
     let grepformat = '%f:%l%m'
 
 	let grepprg = ''
@@ -44,15 +41,12 @@ function! s:create_grep_options(word) abort
 	let last_sub_grepprg = pipeline_script_option
 
     if g:codequery_querytype == s:subcmd_map['FileImporter']
-"        let grepprg = 'cqsearch -s ' . g:codequery_db_path . ' -p ' . g:codequery_querytype . ' -t '
-"                    \ . word . ' -u ' . fuzzy_option
+
 		let last_sub_grepprg = ''
+
     elseif g:codequery_querytype == s:subcmd_map['Callee'] ||
          \ g:codequery_querytype == s:subcmd_map['Caller'] ||
          \ g:codequery_querytype == s:subcmd_map['Member']
-
-"        let grepprg = 'cqsearch -s ' . g:codequery_db_path . ' -p ' . g:codequery_querytype . ' -t '
-"            \ . word . ' -u ' . fuzzy_option . ' \| awk ''{ print $2 " " $1 }'''
 
 		let last_sub_grepprg = ' \| awk ''{ print $2 " " $1 }'''
 

--- a/autoload/codequery/query.vim
+++ b/autoload/codequery/query.vim
@@ -31,32 +31,32 @@ function! s:create_grep_options(word) abort
 
     let grepformat = '%f:%l%m'
 
-	let grepprg = ''
-	let dbs = split(g:codequery_db_path)
-	for i in range(len(dbs))
-	    let grepprg .= 'cqsearch -s ' . dbs[i] . ' -p ' . g:codequery_querytype . ' -t '
-					\ . word . ' -u ' . fuzzy_option . (i + 1 == len(dbs) ? '' : ' && ')
-	endfor
+    let grepprg = ''
+    let dbs = split(g:codequery_db_path)
+    for i in range(len(dbs))
+        let grepprg .= 'cqsearch -s ' . dbs[i] . ' -p ' . g:codequery_querytype . ' -t '
+                    \ . word . ' -u ' . fuzzy_option . (i + 1 == len(dbs) ? '' : ' && ')
+    endfor
 
-	let last_sub_grepprg = pipeline_script_option
+    let last_sub_grepprg = pipeline_script_option
 
     if g:codequery_querytype == s:subcmd_map['FileImporter']
 
-		let last_sub_grepprg = ''
+        let last_sub_grepprg = ''
 
     elseif g:codequery_querytype == s:subcmd_map['Callee'] ||
          \ g:codequery_querytype == s:subcmd_map['Caller'] ||
          \ g:codequery_querytype == s:subcmd_map['Member']
 
-		let last_sub_grepprg = ' \| awk ''{ print $2 " " $1 }'''
+        let last_sub_grepprg = ' \| awk ''{ print $2 " " $1 }'''
 
     elseif g:codequery_querytype == s:subcmd_map['Text']
         let grepformat = ''
         let grepprg = g:codequery_find_text_cmd . ' ' . a:word
-		let last_sub_grepprg = ''
+        let last_sub_grepprg = ''
     endif
 
-	let grepprg .= last_sub_grepprg
+    let grepprg .= last_sub_grepprg
 
     return [grepformat, grepprg]
 endfunction
@@ -199,7 +199,7 @@ function! codequery#query#do_query(word) abort
 
     " Find Text
     if empty(grepformat)
-		echom "@@"
+        echom "@@"
         if g:codequery_find_text_from_current_file_dir == 1
             lcd %:p:h
         endif

--- a/autoload/codequery/query.vim
+++ b/autoload/codequery/query.vim
@@ -28,23 +28,41 @@ function! s:create_grep_options(word) abort
     let pipeline_script_option = ' \| cut -f 2,3'
 
     let grepformat = '%f:%l%m'
-    let grepprg = 'cqsearch -s ' . g:codequery_db_path . ' -p ' . g:codequery_querytype . ' -t '
-                \ . word . ' -u ' . fuzzy_option . pipeline_script_option
+
+"    let grepprg = 'cqsearch -s ' . g:codequery_db_path . ' -p ' . g:codequery_querytype . ' -t '
+"                \ . word . ' -u ' . fuzzy_option . pipeline_script_option
+
+    let grepformat = '%f:%l%m'
+
+	let grepprg = ''
+	let dbs = split(g:codequery_db_path)
+	for i in range(len(dbs))
+	    let grepprg .= 'cqsearch -s ' . dbs[i] . ' -p ' . g:codequery_querytype . ' -t '
+					\ . word . ' -u ' . fuzzy_option . (i + 1 == len(dbs) ? '' : ' && ')
+	endfor
+
+	let last_sub_grepprg = pipeline_script_option
 
     if g:codequery_querytype == s:subcmd_map['FileImporter']
-        let grepprg = 'cqsearch -s ' . g:codequery_db_path . ' -p ' . g:codequery_querytype . ' -t '
-                    \ . word . ' -u ' . fuzzy_option
-
+"        let grepprg = 'cqsearch -s ' . g:codequery_db_path . ' -p ' . g:codequery_querytype . ' -t '
+"                    \ . word . ' -u ' . fuzzy_option
+		let last_sub_grepprg = ''
     elseif g:codequery_querytype == s:subcmd_map['Callee'] ||
          \ g:codequery_querytype == s:subcmd_map['Caller'] ||
          \ g:codequery_querytype == s:subcmd_map['Member']
-        let grepprg = 'cqsearch -s ' . g:codequery_db_path . ' -p ' . g:codequery_querytype . ' -t '
-            \ . word . ' -u ' . fuzzy_option . ' \| awk ''{ print $2 " " $1 }'''
+
+"        let grepprg = 'cqsearch -s ' . g:codequery_db_path . ' -p ' . g:codequery_querytype . ' -t '
+"            \ . word . ' -u ' . fuzzy_option . ' \| awk ''{ print $2 " " $1 }'''
+
+		let last_sub_grepprg = ' \| awk ''{ print $2 " " $1 }'''
 
     elseif g:codequery_querytype == s:subcmd_map['Text']
         let grepformat = ''
         let grepprg = g:codequery_find_text_cmd . ' ' . a:word
+		let last_sub_grepprg = ''
     endif
+
+	let grepprg .= last_sub_grepprg
 
     return [grepformat, grepprg]
 endfunction
@@ -187,6 +205,7 @@ function! codequery#query#do_query(word) abort
 
     " Find Text
     if empty(grepformat)
+		echom "@@"
         if g:codequery_find_text_from_current_file_dir == 1
             lcd %:p:h
         endif


### PR DESCRIPTION
使用 export codequery_base_db_path 指定自定义路径
默认为 $HOME/.doctype
默认也是只识别 前缀为支持的文件类型 并且 后缀为 .db 的生成文件
使用不同的目录存相同名称的 db 文件
CodeQuery 将会最后使用此存储路径进行遍历
同时使用此存储路径树中的所有 db 文件进行搜索